### PR TITLE
fix: don't mix nuget and paket directives

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fsy": {
-      "version": "0.5.0",
+      "version": "0.7.0",
       "commands": [
         "fsy"
       ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
         key: ${{ steps.cache-tools-restore.outputs.cache-primary-key }}
 
     - run: |
-        dotnet fsy run --force test.fsx && \
+        dotnet fsy run --force tests/test.fsx && \
         cd ./fsx && \
         dotnet fsy run --force git.fsx && \
         dotnet fsy run --force solution.fsx && \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
         key: ${{ steps.cache-tools-restore.outputs.cache-primary-key }}
 
     - run: |
+        dotnet fsy run --force test.fsx && \
         cd ./fsx && \
         dotnet fsy run --force git.fsx && \
         dotnet fsy run --force solution.fsx && \

--- a/fsx/solution.fsx
+++ b/fsx/solution.fsx
@@ -1,6 +1,8 @@
-#r "nuget: Ionide.ProjInfo, 0.64.0"
-#r "nuget: Fake.Core.Trace, 6.1.1"
-#r "nuget: Fake.Core.Process, 6.1.1"
+#r "paket: 
+      nuget Ionide.ProjInfo = 0.64.0
+      nuget Fake.Core.Trace = 6.1.1
+      nuget Fake.Core.Process = 6.1.1
+"
 
 #nowarn "57"
 

--- a/tests/simple.fsx
+++ b/tests/simple.fsx
@@ -1,1 +1,0 @@
-#r "paket: nuget System.Security.Cryptography.ProtectedData = 8.0.0"

--- a/tests/simple.fsx
+++ b/tests/simple.fsx
@@ -1,0 +1,1 @@
+#r "paket: nuget System.Security.Cryptography.ProtectedData = 8.0.0"

--- a/tests/test.fsx
+++ b/tests/test.fsx
@@ -1,0 +1,4 @@
+#load "../fsx/git.fsx"
+#load "../fsx/project.fsx"
+#load "../fsx/solution.fsx"
+#load "../fsx/utils.fsx"


### PR DESCRIPTION
This PR removes nuget directives so only paket gets used. (Nuget was used initially as a workaround to a bug that was fixed in https://github.com/queil/fsc-host/pull/24.) Using Nuget introduced another bug - Nuget and Paket use different resolution rules that would cause fsc-host to attempt to load multiple versions of the same assembly which would result in a runtime exception.


