### PR TITLE
add: Git.uniqueDirsWithChanges - handle merge commits

### DIFF
--- a/fsx/git.fsx
+++ b/fsx/git.fsx
@@ -7,50 +7,56 @@ namespace Arquidev.Dbt
 
 open Fake.Core
 open Fake.Tools.Git
-open System
 open System.IO
 
 [<RequireQualifiedAccess>]
 module Git =
 
-  let env = Environment.environVar
-  let pwd = Directory.GetCurrentDirectory()
-  let git = CommandHelper.runSimpleGitCommand
-  
-  let uniqueDirsWithChanges () : string seq =
-  
-      let referenceRev =
-          let maybeTag = Environment.environVarOrNone "MAYBE_TAG"
-  
-          match maybeTag with
-          | Some currentTag ->
-              Trace.logfn $"Building tag: %s{currentTag}"
-              git pwd $"describe --abbrev=0 --tags {currentTag}^"
-          | None ->
-  
-              match Environment.environVarOrFail "BUILD_BASE_REF" with
-              | "0000000000000000000000000000000000000000" ->
-                  Trace.logfn "Base ref is all zeros - defaulting to HEAD^"
-                  "HEAD^"
-              | x -> x
-  
-      Trace.logfn $"Base ref: %s{referenceRev}"
-  
-      let currentRev = env "BUILD_CURRENT_REF"
-  
-      let dirs =
-          FileStatus.getChangedFiles pwd currentRev referenceRev
-          |> Seq.map (snd >> FileInfo >> (fun f -> Path.GetRelativePath(pwd, f.Directory.FullName)))
-          |> Seq.filter ((<>) ".")
-          |> Seq.distinct
-  
-      let info =
-          if dirs |> Seq.isEmpty then
-              "No meaningful changes detected"
-          else
-              "Detected git changes in: "
-  
-      Trace.logfn $"%s{info}"
-  
-      dirs |> Seq.iter (Trace.logfn "%s")
-      dirs
+    let env = Environment.environVarOrDefault
+    let pwd = Directory.GetCurrentDirectory()
+    let git = CommandHelper.runSimpleGitCommand
+
+    let uniqueDirsWithChanges () : string seq =
+
+        let currentRef = env "BUILD_CURRENT_REF" "HEAD"
+        let baseRefOverride = Environment.environVarOrNone "BUILD_BASE_REF"
+
+        Trace.tracefn $"Current ref: %s{currentRef}"
+
+        let baseRefs =
+            let maybeTag = Environment.environVarOrNone "MAYBE_TAG"
+
+            match maybeTag with
+            | Some currentTag ->
+                Trace.logfn $"Building tag: %s{currentTag}"
+                [ git pwd $"describe --abbrev=0 --tags {currentTag}^" ]
+            | None ->
+                match baseRefOverride with
+                | Some ref ->
+                    Trace.tracefn $"Base ref set via $BUILD_BASE_REF: {ref}"
+                    [ ref ]
+                | None ->
+                    Trace.tracef "Base ref(s): "
+                    let output = git pwd $$"""show --no-patch --format="%P" {{currentRef}}"""
+                    output.Split(' ') |> Seq.toList
+
+        let dirs =
+            seq {
+                for baseRef in baseRefs do
+                    yield!
+                        FileStatus.getChangedFiles pwd currentRef baseRef
+                        |> Seq.map (snd >> FileInfo >> (fun f -> Path.GetRelativePath(pwd, f.Directory.FullName)))
+                        |> Seq.filter ((<>) ".")
+            }
+            |> Seq.distinct
+
+        let info =
+            if dirs |> Seq.isEmpty then
+                "No meaningful changes detected"
+            else
+                "Detected git changes in: "
+
+        Trace.tracefn $"%s{info}"
+
+        dirs |> Seq.iter (Trace.logfn "%s")
+        dirs

--- a/tests/test.fsx
+++ b/tests/test.fsx
@@ -2,3 +2,7 @@
 #load "../fsx/project.fsx"
 #load "../fsx/solution.fsx"
 #load "../fsx/utils.fsx"
+
+open Arquidev.Dbt
+
+Git.uniqueDirsWithChanges ()


### PR DESCRIPTION
Auto-detect base ref using: `git show --no-patch --format="%P" $BUILD_CURRENT_REF`. Merge commits will display multiple parents so then we can gather all the dirs for each parents, and pick distinct ones.

Consequences: `$BUILD_BASE_REF` now becomes optional - a way to override the auto-detection.