### PR TITLE
add: git - parse commit message + rename

### DIFF
--- a/fsx/git.fsx
+++ b/fsx/git.fsx
@@ -14,7 +14,7 @@ type GitDiffEnv =
       DBT_MAYBE_TAG: string option }
 
 [<RequireQualifiedAccess>]
-module Git =
+module GitDiff =
 
     let pwd = Directory.GetCurrentDirectory()
     let git = CommandHelper.runSimpleGitCommand

--- a/fsx/pipeline.fsx
+++ b/fsx/pipeline.fsx
@@ -83,7 +83,7 @@ module Pipeline =
                         let lastSuccessfullyBuiltSha = LastSuccessSha.getLastSuccessCommitHash ()
                         printfn $"TEST ONLY: {lastSuccessfullyBuiltSha}"
 
-                Env.get<GitDiffEnv> () |> Git.dirsFromDiff
-            | All -> Git.allDirs ()
+                Env.get<GitDiffEnv> () |> GitDiff.dirsFromDiff
+            | All -> GitDiff.allDirs ()
 
         selectors |> Seq.collect (findRequiredProjects dirs) |> Seq.toList

--- a/tests/test.fsx
+++ b/tests/test.fsx
@@ -9,4 +9,4 @@
 
 open Arquidev.Dbt
 
-Git.dirsFromDiff (Env.get<GitDiffEnv> ())
+GitDiff.dirsFromDiff (Env.get<GitDiffEnv> ())


### PR DESCRIPTION
Added an ability to regex-parse a commit message to extract values.
Renamed Git to GitDiff to be able to use both modules in the same script
Removed redundant semver/tags stuff